### PR TITLE
Feat: 동행글 검색 기능

### DIFF
--- a/src/main/java/org/example/stamppaw_backend/companion/controller/CompanionController.java
+++ b/src/main/java/org/example/stamppaw_backend/companion/controller/CompanionController.java
@@ -105,4 +105,12 @@ public class CompanionController {
         Pageable pageable = PageRequest.of(page, size);
         return ResponseEntity.ok(companionApplyService.getUserApply(pageable, userDetails.getUser().getId()));
     }
+
+    @GetMapping("/search")
+    public ResponseEntity<Page<CompanionResponse>> searchCompanion(@RequestParam(value = "title", defaultValue = "") String title,
+                                                   @RequestParam(value = "page", defaultValue = "0") int page,
+                                                   @RequestParam(value = "size", defaultValue = "3") int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return ResponseEntity.ok(companionService.searchCompanions(pageable, title));
+    }
 }

--- a/src/main/java/org/example/stamppaw_backend/companion/repository/CompanionRepository.java
+++ b/src/main/java/org/example/stamppaw_backend/companion/repository/CompanionRepository.java
@@ -13,4 +13,7 @@ public interface CompanionRepository extends JpaRepository<Companion, Long> {
 
     @Query("select c from Companion c order by c.registeredAt desc ")
     Page<Companion> findAllOrderByregisteredAt(Pageable pageable);
+
+    @Query("SELECT c from Companion c WHERE c.title LIKE %:title% ORDER BY c.registeredAt desc ")
+    Page<Companion> findByTitle(Pageable pageable, String title);
 }

--- a/src/main/java/org/example/stamppaw_backend/companion/service/CompanionService.java
+++ b/src/main/java/org/example/stamppaw_backend/companion/service/CompanionService.java
@@ -120,6 +120,12 @@ public class CompanionService {
         companion.updateStatus(status);
     }
 
+    @Transactional(readOnly = true)
+    public Page<CompanionResponse> searchCompanions (Pageable pageable, String title) {
+        Page<Companion> companions = companionRepository.findByTitle(pageable, title);
+        return companions.map(CompanionResponse::fromEntity);
+    }
+
     private Companion getCompanionOrException(Long postId) {
         return companionRepository.findById(postId)
                 .orElseThrow(() -> new StampPawException(ErrorCode.COMPANION_NOT_FOUND));


### PR DESCRIPTION
---
title: "[Feat]  동행글 검색 기능"
---

> ### 🔍 관련 이슈
<!-- 연결된 이슈 번호를 적어주세요 (예: closes #45) -->
- closes #72

> ### 🧩 PR 요약
<!-- 어떤 작업을 했는지 간단히 설명해주세요 -->
- 키워드를 입력했을 때 데이터를 조회하는 API를 구현했습니다.

> ### 🧱 변경 사항
<!-- 주요 코드 변경점을 리스트업 해주세요 -->
- [ ] search 관련 쿼리문 작성
- [ ] `searchCompanion` 메소드 추가

> ### 🧪 테스트 방법
<!-- 로컬 또는 서버에서 테스트한 방법을 적어주세요 -->
1. api/companion/search?title=서울&page=0 (제목에 "서울" 이 들어가는 첫번째 페이지 결과)
<img width="567" height="929" alt="image" src="https://github.com/user-attachments/assets/f1dd90f7-ff62-4733-86cb-a105887fc6fb" />

2. api/companion/search (아무런 키워드를 입력하지 않았을 때는 전체 데이터 중 3개 잘라서 결과 나옴)
<img width="541" height="914" alt="image" src="https://github.com/user-attachments/assets/43025dd3-b631-4c4d-ada1-5a6438cd64e2" />

> ### 🧠 참고 사항
<!-- 리뷰어가 알아두면 좋을 추가 내용, 의도, 고려 사항 등을 적어주세요 -->
- 동행글은 title을 기준으로 키워드가 들어가는지 판별해서 정보를 반환하도록 구현했습니다.
- 검색 결과 데이터 정렬은 등록 최신순으로 반환됩니다.
